### PR TITLE
[babbling] fix a bug for the right arm, old code read the left arm va…

### DIFF
--- a/src/modules/babbling/src/babbling.cpp
+++ b/src/modules/babbling/src/babbling.cpp
@@ -297,10 +297,11 @@ void Babbling::babblingCommands(double &t, int j_idx) {
 
         if (part == "right_arm") {
             encodersUsed = encodersRightArm;
+            okEncArm = encsRightArm->getEncoders(encodersUsed.data());
         } else {
             encodersUsed = encodersLeftArm;
+            okEncArm = encsLeftArm->getEncoders(encodersUsed.data());
         }
-        okEncArm = encsLeftArm->getEncoders(encodersUsed.data());
 
         yDebug() << "j_idx: " << j_idx;
 


### PR DESCRIPTION
This PR is for fixing a bug in the `babbling` module. The old code use `left arm encoder` for both left and right arm, leading to weird behavior during `right arm` babbling.

Cheers,
Phuong